### PR TITLE
Make it possible for AgentId and InfoProxyId to be exported

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentInterface.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentInterface.cs
@@ -1,4 +1,5 @@
 using FFXIVClientStructs.FFXIV.Client.UI;
+using FFXIVClientStructs.FFXIV.Client.UI.Agent;
 
 namespace FFXIVClientStructs.FFXIV.Component.GUI;
 
@@ -25,4 +26,7 @@ public unsafe partial struct AgentInterface {
 
     [VirtualFunction(8)]
     public partial uint GetAddonID();
+
+    [MemberFunction("E8 ?? ?? ?? ?? 8B 6E 20")]
+    public partial AgentInterface* GetAgentByInternalId(AgentId agentID);
 }

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentModule.cs
@@ -20,11 +20,10 @@ public unsafe partial struct AgentModule {
     [FieldOffset(0x20)] public fixed byte Agents[441 * 8];
 
     [MemberFunction("E8 ?? ?? ?? ?? 0F B7 A8")]
-    public partial AgentInterface* GetAgentByInternalID(uint agentID);
+    public partial AgentInterface* GetAgentByInternalId(AgentId agentID);
 
-    public AgentInterface* GetAgentByInternalId(AgentId agentId) {
-        return GetAgentByInternalID((uint)agentId);
-    }
+    public AgentInterface* GetAgentByInternalID(uint agentId)
+        => GetAgentByInternalId((AgentId)agentId);
 }
 
 public enum AgentId : uint {

--- a/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoModule.cs
@@ -14,11 +14,11 @@ public unsafe partial struct InfoModule {
     [FieldOffset(0x1BC8)] public Utf8String UnkString3;
     [FieldOffset(0x1C30)] public ulong OnlineStatusFlags;
 
-    public InfoProxyInterface* GetInfoProxyById(InfoProxyId id)
-        => GetInfoProxyById((uint)id);
-
     [MemberFunction("E8 ?? ?? ?? ?? 48 8B 55 68")]
-    public partial InfoProxyInterface* GetInfoProxyById(uint id);
+    public partial InfoProxyInterface* GetInfoProxyById(InfoProxyId id);
+
+    public InfoProxyInterface* GetInfoProxyById(uint id)
+        => GetInfoProxyById((InfoProxyId)id);
 
     /// <summary>
     /// Checks if the local player has a specific online status set.

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -3882,8 +3882,8 @@ classes:
       0x1402259A0: ctor
       0x14022B150: Finalize
       0x14022B1B0: Update
-      0x14022B3A0: GetAgentByInternalID
-      0x14022B3B0: GetAgentByInternalID_2  # dupe?
+      0x14022B3A0: GetAgentByInternalId
+      0x14022B3B0: GetAgentByInternalId_2  # dupe?
       0x14022B450: HideAgent
       0x14022B470: HideAgentIfActive
       0x14022B4C0: IsAgentActive


### PR DESCRIPTION
Swapping the functions, so that the `[MemberFunction]` one uses the enum, makes CExporter export AgentId and InfoProxyId:

![3iRRpzzSH8](https://github.com/wolfcomp/FFXIVClientStructs/assets/96642047/d3e7fc3d-2326-41d6-b200-cc575df61dfd)

![fhyBrcXnt6](https://github.com/wolfcomp/FFXIVClientStructs/assets/96642047/192bbbaa-7104-4179-a8ea-49337f92e660)


🙂 👍